### PR TITLE
bin/graph_altimeter_batch: scan accounts in batches

### DIFF
--- a/bin/graph_altimeter_batch.py
+++ b/bin/graph_altimeter_batch.py
@@ -34,10 +34,9 @@ def main():
 def run_scan():
     """Scans the accounts defined in the Asset Inventory using Altimeter."""
     asset_inventory_api_url = os.getenv('ASSET_INVENTORY_API_URL', None)
-    accounts_to_scan = os.getenv("ACCOUNTS_TO_SCAN", None)
-    if asset_inventory_api_url is None:
-        if accounts_to_scan is None:
-            raise EnvVarNotSetError('ASSET_INVENTORY_API_URL')
+    accounts_to_scan = os.getenv("ACCOUNTS", None)
+    if asset_inventory_api_url is None and accounts_to_scan is None:
+        raise EnvVarNotSetError('ASSET_INVENTORY_API_URL')
 
     target_account_role = os.getenv('TARGET_ACCOUNT_ROLE', None)
     if target_account_role is None:
@@ -61,13 +60,11 @@ def run_scan():
         batches = batches + 1
     for i in range(0, batches):
         from_acc = i * accounts_per_batch
-        to_acc = from_acc + accounts_per_batch
-        if to_acc > n_of_accounts:
-            to_acc = from_acc + (n_of_accounts % accounts_per_batch)
+        to_acc = min(from_acc + accounts_per_batch, n_of_accounts)
         batch = accounts[from_acc:to_acc]
         logger.info(
             "scanning accounts %s",
-            str(accounts)
+            batch
         )
         config = AltimeterConfig.from_env()
         scan_config = config.config_dict(

--- a/env/local.env
+++ b/env/local.env
@@ -4,12 +4,12 @@ ASSET_INVENTORY_API_URL=http://example.com/asset-inventory/v1
 # TODO: Add ACCOUNTS env var. If present, it should be used instead of the
 # ASSET_INVENTORY_API_URL.
 
-# Defines a comma separated list of accounts to scan, when defined the Asset
+# Defines a comma-separated list of accounts to scan, when defined the Asset
 # Inventory is not queried.
-ACCOUNTS_TO_SCAN = 123456789012,123456789013
+ACCOUNTS=123456789012,123456789013
 
 # Defines the number of accounts to be scanned per each batch.
-ACCOUNTS_BATCH = 2
+ACCOUNTS_BATCH=2
 
 # Number of threads to spaws to scan AWS accounts.
 MAX_ACCOUNT_SCAN_THREADS=1

--- a/env/local.env
+++ b/env/local.env
@@ -4,6 +4,10 @@ ASSET_INVENTORY_API_URL=http://example.com/asset-inventory/v1
 # TODO: Add ACCOUNTS env var. If present, it should be used instead of the
 # ASSET_INVENTORY_API_URL.
 
+# Defines a comma separated list of accounts to scan, when defined the Asset
+# Inventory is not queried.
+ACCOUNTS_TO_SCAN = 123456789012,123456789013
+
 # Defines the number of accounts to be scanned per each batch.
 ACCOUNTS_BATCH = 2
 

--- a/env/local.env
+++ b/env/local.env
@@ -4,6 +4,9 @@ ASSET_INVENTORY_API_URL=http://example.com/asset-inventory/v1
 # TODO: Add ACCOUNTS env var. If present, it should be used instead of the
 # ASSET_INVENTORY_API_URL.
 
+# Defines the number of accounts to be scanned per each batch.
+ACCOUNTS_BATCH = 2
+
 # Number of threads to spaws to scan AWS accounts.
 MAX_ACCOUNT_SCAN_THREADS=1
 


### PR DESCRIPTION
This PR adds two new config parameters:

* ACCOUNTS_BATCH defines the number of accounts to be scanned in the
  same Altimeter batch.
* ACCOUNTS defines a comma-separated list of account ids. When
  specified those accounts will be the ones scanned instead of the ones
  provided by the Asset Inventory.