### PR TITLE
all: fix Neptune compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone --depth 1 --branch amazon-neptune-tools-1.4 \
 # Stage for the graph-altimeter dev image.
 FROM python:3.9.6-alpine
 
-RUN apk add gcc musl-dev libffi-dev  git
+RUN apk add gcc musl-dev libffi-dev git
 COPY requirements/requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt  && rm -f /tmp/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN git clone --depth 1 --branch amazon-neptune-tools-1.4 \
 # Stage for the graph-altimeter dev image.
 FROM python:3.9.6-alpine
 
-RUN apk add gcc musl-dev libffi-dev
-
+RUN apk add gcc musl-dev libffi-dev  git
 COPY requirements/requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt  && rm -f /tmp/requirements.txt
 

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -10,7 +10,7 @@ RUN git clone --depth 1 --branch amazon-neptune-tools-1.4 \
 # Stage for the graph-altimeter dev image.
 FROM python:3.9.6-alpine
 
-RUN apk add gcc musl-dev libffi-dev
+RUN apk add gcc musl-dev libffi-dev git
 
 COPY requirements/requirements.txt requirements/requirements-dev.txt /tmp/
 RUN pip install -r /tmp/requirements.txt -r /tmp/requirements-dev.txt && \

--- a/graph_altimeter/scan/__init__.py
+++ b/graph_altimeter/scan/__init__.py
@@ -100,6 +100,7 @@ def run(config, resource_specs=None):  # pylint: disable=too-many-locals
     # TODO: The following two operations are not transactional. This should be
     # reviewed.
     logger.debug('scan %s: writing results in Gremlin DB', scan_id)
+
     neptune_client.write_to_neptune_lpg(graph, scan_id)
     link_snapshot_with_universe(neptune_client, snapshot_vertex_id)
     logger.debug('scan %s: finished writting results in Gremlin DB', scan_id)
@@ -169,7 +170,7 @@ class AltimeterUniverseGraph:
         for v in vertices:
             edges.append(
                 {
-                    "~id": uuid.uuid1(),
+                    "~id": str(uuid.uuid1()),
                     "~label": "includes",
                     "~from": "altimeter_snapshot",
                     "~to": v["~id"],
@@ -190,7 +191,7 @@ def _create_vertex(v_id, scan_id):
         "~id": v_id,
         "~label": label,
         "scan_id": scan_id,
-        "arn": v_id,
+        "arn": str(v_id),
     }
     return new_vertex
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
 # graph_altimeter dependencies.
 gremlinpython==3.4.12
 # Altimeter fork.
+# TODO: revert to upstream once fixes are applied.
 git+https://github.com/manelmontilla/altimeter.git@dev
 
 # neptune_python_utils dependencies.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,7 @@
 # graph_altimeter dependencies.
 gremlinpython==3.4.12
-altimeter==6.3.13
+# Altimeter fork.
+git+https://github.com/manelmontilla/altimeter.git@fix-lpg
 
 # neptune_python_utils dependencies.
 boto3==1.20.44

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 # graph_altimeter dependencies.
 gremlinpython==3.4.12
 # Altimeter fork.
-git+https://github.com/manelmontilla/altimeter.git@fix-lpg
+git+https://github.com/manelmontilla/altimeter.git@dev
 
 # neptune_python_utils dependencies.
 boto3==1.20.44


### PR DESCRIPTION
This PR modifies graph-altimeter so:

* It uses the branch `dev` of an Altimeter fork that fixes some lpg-related
  issues.
* It avoids using the UUID type in vertices, so the generated graphs are
  compatible with Neptune.