### PR TITLE
graph_altimeter/scan: add account_id to new created vertices

### DIFF
--- a/tests/testdata/graph.json
+++ b/tests/testdata/graph.json
@@ -1,705 +1,5 @@
 [
   {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "ec2:flow-log",
-      "flow_log_status": "ACTIVE",
-      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
-      "account_id": "123456789012",
-      "log_destination": "arn:aws:s3:::test_bucket",
-      "traffic_type": "ALL",
-      "deliver_logs_status": "SUCCESS",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
-      "log_destination_type": "s3"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "sa-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/sa-east-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "af-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/af-south-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-3"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-north-1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "af-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/af-south-1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-west-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "iam:policy",
-      "account_id": "123456789012",
-      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
-      "name": "test_policy_1",
-      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}], \"Version\": \"2012-10-17\"}",
-      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
-      "default_version_id": "v1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "statement",
-      "account_id": "123456789012",
-      "effect": "Allow",
-      "action": "sts:AssumeRole"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ca-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ca-central-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "ec2:volume",
-      "availability_zone": "us-east-1a",
-      "account_id": "123456789012",
-      "volume_type": "gp2",
-      "size": 128,
-      "encrypted": false,
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "ec2:subnet",
-      "last_ip": 167772415,
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/24",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
-      "first_ip": 167772160
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-central-1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "ec2:subnet",
-      "last_ip": 167772415,
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/24",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
-      "first_ip": 167772160
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "ec2:flow-log",
-      "flow_log_status": "ACTIVE",
-      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
-      "account_id": "123456789012",
-      "log_destination": "arn:aws:s3:::test_bucket",
-      "traffic_type": "ALL",
-      "deliver_logs_status": "SUCCESS",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
-      "log_destination_type": "s3"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "ec2:flow-log",
-      "flow_log_status": "ACTIVE",
-      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
-      "account_id": "123456789012",
-      "log_destination": "arn:aws:s3:::test_bucket",
-      "traffic_type": "ALL",
-      "deliver_logs_status": "SUCCESS",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
-      "log_destination_type": "s3"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-east-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/ap-east-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-northwest-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-south-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "sa-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/sa-east-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "me-south-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/me-south-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "iam:policy",
-      "account_id": "123456789012",
-      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
-      "name": "test_policy_1",
-      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}], \"Version\": \"2012-10-17\"}",
-      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
-      "default_version_id": "v1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-central-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-north-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "principal",
-      "account_id": "123456789012",
-      "service": "lambda.amazonaws.com"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-south-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-north-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    }
-  },
-  {
     "T.label": "resource_link",
     "T.v_in": {
       "T.label": "account",
@@ -712,361 +12,6 @@
       "name": "ap-northeast-2",
       "opt_in_status": "opt-in-not-required",
       "arn": "arn:aws:::123456789012:region/ap-northeast-2"
-    }
-  },
-  {
-    "T.label": "assume_role_policy_document",
-    "T.v_in": {
-      "T.label": "assume_role_policy_document",
-      "account_id": "123456789012",
-      "version": "2012-10-17"
-    },
-    "T.v_out": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-south-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "transient_resource_link",
-    "T.v_in": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    },
-    "T.v_out": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-3"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-3"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-3"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "ec2:volume",
-      "availability_zone": "us-east-1a",
-      "account_id": "123456789012",
-      "volume_type": "gp2",
-      "size": 128,
-      "encrypted": false,
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-west-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    }
-  },
-  {
-    "T.label": "statement",
-    "T.v_in": {
-      "T.label": "statement",
-      "account_id": "123456789012",
-      "effect": "Allow",
-      "action": "sts:AssumeRole"
-    },
-    "T.v_out": {
-      "T.label": "assume_role_policy_document",
-      "account_id": "123456789012",
-      "version": "2012-10-17"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    },
-    "T.v_out": {
-      "T.label": "ec2:subnet",
-      "last_ip": 167772415,
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/24",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
-      "first_ip": 167772160
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "transient_resource_link",
-    "T.v_in": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    },
-    "T.v_out": {
-      "T.label": "ec2:flow-log",
-      "flow_log_status": "ACTIVE",
-      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
-      "account_id": "123456789012",
-      "log_destination": "arn:aws:s3:::test_bucket",
-      "traffic_type": "ALL",
-      "deliver_logs_status": "SUCCESS",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
-      "log_destination_type": "s3"
     }
   },
   {
@@ -1094,11 +39,101 @@
   {
     "T.label": "identified_resource",
     "T.v_in": {
+      "T.label": "ec2:flow-log",
+      "flow_log_status": "ACTIVE",
+      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "account_id": "123456789012",
+      "log_destination": "arn:aws:s3:::test_bucket",
+      "traffic_type": "ALL",
+      "deliver_logs_status": "SUCCESS",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
+      "log_destination_type": "s3"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "us-west-1",
+      "name": "ca-central-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-west-1"
+      "arn": "arn:aws:::123456789012:region/ca-central-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "lambda:function",
+      "account_id": "123456789012",
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-south-1"
     },
     "T.v_out": {
       "T.label": "metadata",
@@ -1113,7 +148,7 @@
       "account_id": "123456789012",
       "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
       "name": "test_policy_1",
-      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}], \"Version\": \"2012-10-17\"}",
+      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}, {\"Action\": \"s3:GetObject\", \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::test_bucket\"}], \"Version\": \"2012-10-17\"}",
       "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
       "default_version_id": "v1"
     },
@@ -1122,58 +157,6 @@
     }
   },
   {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "af-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/af-south-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-east-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/ap-east-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-2"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
     "T.label": "resource_link",
     "T.v_in": {
       "T.label": "account",
@@ -1181,288 +164,15 @@
       "arn": "arn:aws::::account/123456789012"
     },
     "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-east-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/ap-east-1"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-3"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-south-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ca-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ca-central-1"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ca-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ca-central-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-central-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "ec2:volume",
-      "availability_zone": "us-east-1a",
-      "account_id": "123456789012",
-      "volume_type": "gp2",
-      "size": 128,
-      "encrypted": false,
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-north-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-south-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
       "T.label": "region",
       "account_id": "123456789012",
       "name": "eu-west-2",
       "opt_in_status": "opt-in-not-required",
       "arn": "arn:aws:::123456789012:region/eu-west-2"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
     }
   },
   {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-3"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "me-south-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/me-south-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "sa-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/sa-east-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-2"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
+    "T.label": "identified_resource",
     "T.v_in": {
       "T.label": "region",
       "account_id": "123456789012",
@@ -1471,59 +181,9 @@
       "arn": "arn:aws:::123456789012:region/us-west-1"
     },
     "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-west-2"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-north-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
     }
   },
   {
@@ -1536,46 +196,9 @@
     "T.v_out": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "eu-south-1",
+      "name": "us-west-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-south-1"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-northwest-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
+      "arn": "arn:aws:::123456789012:region/us-west-1"
     }
   },
   {
@@ -1592,14 +215,50 @@
   {
     "T.label": "identified_resource",
     "T.v_in": {
-      "T.label": "assume_role_policy_document",
+      "T.label": "region",
       "account_id": "123456789012",
-      "version": "2012-10-17"
+      "name": "us-gov-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
     },
     "T.v_out": {
       "T.label": "metadata",
       "name": "alti",
       "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "ec2:subnet",
+      "last_ip": 167772415,
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/24",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
+      "first_ip": 167772160
     }
   },
   {
@@ -1615,6 +274,26 @@
     }
   },
   {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    },
+    "T.v_out": {
+      "T.label": "ec2:subnet",
+      "last_ip": 167772415,
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/24",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
+      "first_ip": 167772160
+    }
+  },
+  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "principal",
@@ -1623,6 +302,39 @@
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "ec2:flow-log",
+      "flow_log_status": "ACTIVE",
+      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "account_id": "123456789012",
+      "log_destination": "arn:aws:s3:::test_bucket",
+      "traffic_type": "ALL",
+      "deliver_logs_status": "SUCCESS",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
+      "log_destination_type": "s3"
+    }
+  },
+  {
+    "T.label": "statement",
+    "T.v_in": {
+      "T.label": "statement",
+      "account_id": "123456789012",
+      "effect": "Allow",
+      "action": "sts:AssumeRole"
+    },
+    "T.v_out": {
+      "T.label": "assume_role_policy_document",
+      "account_id": "123456789012",
+      "version": "2012-10-17"
     }
   },
   {
@@ -1641,30 +353,33 @@
     }
   },
   {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
     "T.label": "identified_resource",
     "T.v_in": {
-      "T.label": "region",
+      "T.label": "lambda:function",
       "account_id": "123456789012",
-      "name": "eu-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-north-1"
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
     },
     "T.v_out": {
       "T.label": "metadata",
       "name": "alti",
       "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "lambda:function",
+      "account_id": "123456789012",
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
     }
   },
   {
@@ -1681,6 +396,21 @@
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-south-1"
     }
   },
   {
@@ -1716,6 +446,19 @@
     }
   },
   {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "ec2:subnet",
@@ -1731,17 +474,33 @@
     }
   },
   {
-    "T.label": "principal",
+    "T.label": "identified_resource",
     "T.v_in": {
-      "T.label": "principal",
+      "T.label": "region",
       "account_id": "123456789012",
-      "service": "lambda.amazonaws.com"
+      "name": "ap-northeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
     },
     "T.v_out": {
-      "T.label": "statement",
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
       "account_id": "123456789012",
-      "effect": "Allow",
-      "action": "sts:AssumeRole"
+      "name": "sa-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/sa-east-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
     }
   },
   {
@@ -1768,9 +527,308 @@
     "T.v_out": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "cn-northwest-1",
+      "name": "ap-east-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/ap-east-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "ec2:volume",
+      "availability_zone": "us-east-1a",
+      "account_id": "123456789012",
+      "volume_type": "gp2",
+      "size": 128,
+      "encrypted": false,
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-east-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/ap-east-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-south-1"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "af-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/af-south-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-east-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/ap-east-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-north-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-central-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-central-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-2"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "af-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/af-south-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-3"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-3"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "me-south-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/me-south-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-south-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-central-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-central-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "ec2:volume",
+      "availability_zone": "us-east-1a",
+      "account_id": "123456789012",
+      "volume_type": "gp2",
+      "size": 128,
+      "encrypted": false,
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "transient_resource_link",
+    "T.v_in": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    },
+    "T.v_out": {
+      "T.label": "lambda:function",
+      "account_id": "123456789012",
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
     }
   },
   {
@@ -1800,6 +858,172 @@
       "arn": "arn:aws:::123456789012:region/us-east-1"
     },
     "T.v_out": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-3"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "ec2:flow-log",
+      "flow_log_status": "ACTIVE",
+      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "account_id": "123456789012",
+      "log_destination": "arn:aws:s3:::test_bucket",
+      "traffic_type": "ALL",
+      "deliver_logs_status": "SUCCESS",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
+      "log_destination_type": "s3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ca-central-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ca-central-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
       "T.label": "lambda:function",
       "account_id": "123456789012",
       "function_name": "test_lambda_function_1",
@@ -1808,16 +1032,461 @@
     }
   },
   {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-central-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-central-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "assume_role_policy_document",
+    "T.v_in": {
+      "T.label": "assume_role_policy_document",
+      "account_id": "123456789012",
+      "version": "2012-10-17"
+    },
+    "T.v_out": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-north-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
     "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-south-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-south-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
     "T.v_in": {
       "T.label": "account",
       "account_id": "123456789012",
       "arn": "arn:aws::::account/123456789012"
     },
     "T.v_out": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-west-2"
+    },
+    "T.v_out": {
       "T.label": "metadata",
       "name": "alti",
       "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-2"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "iam:policy",
+      "account_id": "123456789012",
+      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
+      "name": "test_policy_1",
+      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}, {\"Action\": \"s3:GetObject\", \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::test_bucket\"}], \"Version\": \"2012-10-17\"}",
+      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
+      "default_version_id": "v1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ca-central-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ca-central-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-northwest-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-3"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "ec2:subnet",
+      "last_ip": 167772415,
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/24",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
+      "first_ip": 167772160
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    }
+  },
+  {
+    "T.label": "transient_resource_link",
+    "T.v_in": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    },
+    "T.v_out": {
+      "T.label": "ec2:flow-log",
+      "flow_log_status": "ACTIVE",
+      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "account_id": "123456789012",
+      "log_destination": "arn:aws:s3:::test_bucket",
+      "traffic_type": "ALL",
+      "deliver_logs_status": "SUCCESS",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
+      "log_destination_type": "s3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "statement",
+      "account_id": "123456789012",
+      "effect": "Allow",
+      "action": "sts:AssumeRole"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "me-south-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/me-south-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "sa-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/sa-east-1"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "sa-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/sa-east-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-2"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "principal",
+    "T.v_in": {
+      "T.label": "principal",
+      "account_id": "123456789012",
+      "service": "lambda.amazonaws.com"
+    },
+    "T.v_out": {
+      "T.label": "statement",
+      "account_id": "123456789012",
+      "effect": "Allow",
+      "action": "sts:AssumeRole"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
     }
   },
   {
@@ -1836,6 +1505,124 @@
     }
   },
   {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "assume_role_policy_document",
+      "account_id": "123456789012",
+      "version": "2012-10-17"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-west-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "iam:policy",
+      "account_id": "123456789012",
+      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
+      "name": "test_policy_1",
+      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}, {\"Action\": \"s3:GetObject\", \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::test_bucket\"}], \"Version\": \"2012-10-17\"}",
+      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
+      "default_version_id": "v1"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-west-2"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "principal",
+      "account_id": "123456789012",
+      "service": "lambda.amazonaws.com"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "iam_resource_link",
+    "T.v_in": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
+    },
+    "T.v_out": {
+      "T.label": "iam:policy",
+      "account_id": "123456789012",
+      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
+      "name": "test_policy_1",
+      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}, {\"Action\": \"s3:GetObject\", \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::test_bucket\"}], \"Version\": \"2012-10-17\"}",
+      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
+      "default_version_id": "v1"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    }
+  },
+  {
     "T.label": "resource_link",
     "T.v_in": {
       "T.label": "account",
@@ -1845,9 +1632,240 @@
     "T.v_out": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "us-east-1",
+      "name": "us-east-2",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
+      "arn": "arn:aws:::123456789012:region/us-east-2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "ec2:volume",
+      "availability_zone": "us-east-1a",
+      "account_id": "123456789012",
+      "volume_type": "gp2",
+      "size": 128,
+      "encrypted": false,
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-north-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-northwest-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-northwest-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-north-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-3"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "af-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/af-south-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-north-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-north-1"
     }
   }
 ]

--- a/tests/testdata/graph.json
+++ b/tests/testdata/graph.json
@@ -1,352 +1,6 @@
 [
   {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
     "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-northwest-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "iam_resource_link",
-    "T.v_in": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    },
-    "T.v_out": {
-      "T.label": "iam:policy",
-      "account_id": "123456789012",
-      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
-      "name": "test_policy_1",
-      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}, {\"Action\": \"s3:GetObject\", \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::test_bucket\"}], \"Version\": \"2012-10-17\"}",
-      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
-      "default_version_id": "v1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-west-1"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "assume_role_policy_document",
-      "account_id": "123456789012",
-      "version": "2012-10-17"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-south-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "statement",
-      "account_id": "123456789012",
-      "effect": "Allow",
-      "action": "sts:AssumeRole"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "af-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/af-south-1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "principal",
-      "account_id": "123456789012",
-      "service": "lambda.amazonaws.com"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-north-1"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "iam:policy",
-      "account_id": "123456789012",
-      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
-      "name": "test_policy_1",
-      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}, {\"Action\": \"s3:GetObject\", \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::test_bucket\"}], \"Version\": \"2012-10-17\"}",
-      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
-      "default_version_id": "v1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-central-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-west-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "ec2:volume",
-      "availability_zone": "us-east-1a",
-      "account_id": "123456789012",
-      "volume_type": "gp2",
-      "size": 128,
-      "encrypted": false,
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "assume_role_policy_document",
-      "account_id": "123456789012",
-      "version": "2012-10-17"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "includes",
     "T.v_in": {
       "T.label": "ec2:flow-log",
       "flow_log_status": "ACTIVE",
@@ -359,37 +13,9 @@
       "log_destination_type": "s3"
     },
     "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-northwest-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "ec2:subnet",
-      "last_ip": 167772415,
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/24",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
-      "first_ip": 167772160
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
     }
   },
   {
@@ -412,9 +38,9 @@
     "T.v_in": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "eu-west-1",
+      "name": "af-south-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-1"
+      "arn": "arn:aws:::123456789012:region/af-south-1"
     },
     "T.v_out": {
       "T.label": "metadata",
@@ -423,17 +49,340 @@
     }
   },
   {
-    "T.label": "includes",
+    "T.label": "resource_link",
     "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
       "T.label": "ec2:vpc",
       "account_id": "123456789012",
       "cidr_block": "10.0.0.0/16",
       "state": "available",
       "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
       "is_default": true
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
     },
     "T.v_out": {
-      "T.label": "altimeter_snapshot"
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-north-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "af-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/af-south-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-west-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "iam:policy",
+      "account_id": "123456789012",
+      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
+      "name": "test_policy_1",
+      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}], \"Version\": \"2012-10-17\"}",
+      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
+      "default_version_id": "v1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "statement",
+      "account_id": "123456789012",
+      "effect": "Allow",
+      "action": "sts:AssumeRole"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ca-central-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ca-central-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "ec2:volume",
+      "availability_zone": "us-east-1a",
+      "account_id": "123456789012",
+      "volume_type": "gp2",
+      "size": 128,
+      "encrypted": false,
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "lambda:function",
+      "account_id": "123456789012",
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "ec2:subnet",
+      "last_ip": 167772415,
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/24",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
+      "first_ip": 167772160
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
     }
   },
   {
@@ -452,14 +401,72 @@
     }
   },
   {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "ec2:subnet",
+      "last_ip": 167772415,
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/24",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
+      "first_ip": 167772160
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "ec2:flow-log",
+      "flow_log_status": "ACTIVE",
+      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "account_id": "123456789012",
+      "log_destination": "arn:aws:s3:::test_bucket",
+      "traffic_type": "ALL",
+      "deliver_logs_status": "SUCCESS",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
+      "log_destination_type": "s3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "ec2:flow-log",
+      "flow_log_status": "ACTIVE",
+      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "account_id": "123456789012",
+      "log_destination": "arn:aws:s3:::test_bucket",
+      "traffic_type": "ALL",
+      "deliver_logs_status": "SUCCESS",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
+      "log_destination_type": "s3"
+    }
+  },
+  {
     "T.label": "identified_resource",
     "T.v_in": {
-      "T.label": "ec2:vpc",
+      "T.label": "region",
       "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
+      "name": "ap-east-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/ap-east-1"
     },
     "T.v_out": {
       "T.label": "metadata",
@@ -483,17 +490,326 @@
     }
   },
   {
-    "T.label": "principal",
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-northwest-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-south-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "sa-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/sa-east-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "me-south-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/me-south-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "iam:policy",
+      "account_id": "123456789012",
+      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
+      "name": "test_policy_1",
+      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}], \"Version\": \"2012-10-17\"}",
+      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
+      "default_version_id": "v1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-central-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-central-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-north-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
     "T.v_in": {
       "T.label": "principal",
       "account_id": "123456789012",
       "service": "lambda.amazonaws.com"
     },
     "T.v_out": {
-      "T.label": "statement",
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
       "account_id": "123456789012",
-      "effect": "Allow",
-      "action": "sts:AssumeRole"
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-south-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/cn-north-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-2"
+    }
+  },
+  {
+    "T.label": "assume_role_policy_document",
+    "T.v_in": {
+      "T.label": "assume_role_policy_document",
+      "account_id": "123456789012",
+      "version": "2012-10-17"
+    },
+    "T.v_out": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-south-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "transient_resource_link",
+    "T.v_in": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    },
+    "T.v_out": {
+      "T.label": "lambda:function",
+      "account_id": "123456789012",
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-3"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
     }
   },
   {
@@ -524,6 +840,233 @@
       "T.label": "metadata",
       "name": "alti",
       "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-northeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-northeast-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "ec2:volume",
+      "availability_zone": "us-east-1a",
+      "account_id": "123456789012",
+      "volume_type": "gp2",
+      "size": 128,
+      "encrypted": false,
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-west-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    }
+  },
+  {
+    "T.label": "statement",
+    "T.v_in": {
+      "T.label": "statement",
+      "account_id": "123456789012",
+      "effect": "Allow",
+      "action": "sts:AssumeRole"
+    },
+    "T.v_out": {
+      "T.label": "assume_role_policy_document",
+      "account_id": "123456789012",
+      "version": "2012-10-17"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    },
+    "T.v_out": {
+      "T.label": "ec2:subnet",
+      "last_ip": 167772415,
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/24",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
+      "first_ip": 167772160
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-gov-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "transient_resource_link",
+    "T.v_in": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    },
+    "T.v_out": {
+      "T.label": "ec2:flow-log",
+      "flow_log_status": "ACTIVE",
+      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "account_id": "123456789012",
+      "log_destination": "arn:aws:s3:::test_bucket",
+      "traffic_type": "ALL",
+      "deliver_logs_status": "SUCCESS",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
+      "log_destination_type": "s3"
     }
   },
   {
@@ -549,33 +1092,33 @@
     }
   },
   {
-    "T.label": "resource_link",
+    "T.label": "identified_resource",
     "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "eu-west-1",
+      "name": "us-west-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-1"
+      "arn": "arn:aws:::123456789012:region/us-west-1"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
     }
   },
   {
-    "T.label": "resource_link",
+    "T.label": "includes",
     "T.v_in": {
-      "T.label": "account",
+      "T.label": "iam:policy",
       "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
+      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
+      "name": "test_policy_1",
+      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}], \"Version\": \"2012-10-17\"}",
+      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
+      "default_version_id": "v1"
     },
     "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ca-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ca-central-1"
+      "T.label": "altimeter_snapshot"
     }
   },
   {
@@ -592,55 +1135,6 @@
     }
   },
   {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-south-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "s3:bucket",
-      "account_id": "123456789012",
-      "name": "test_bucket",
-      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    },
-    "T.v_out": {
-      "T.label": "ec2:subnet",
-      "last_ip": 167772415,
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/24",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
-      "first_ip": 167772160
-    }
-  },
-  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -654,54 +1148,6 @@
     }
   },
   {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "ec2:subnet",
-      "last_ip": 167772415,
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/24",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
-      "first_ip": 167772160
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    }
-  },
-  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -712,35 +1158,6 @@
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-north-1"
-    }
-  },
-  {
-    "T.label": "statement",
-    "T.v_in": {
-      "T.label": "statement",
-      "account_id": "123456789012",
-      "effect": "Allow",
-      "action": "sts:AssumeRole"
-    },
-    "T.v_out": {
-      "T.label": "assume_role_policy_document",
-      "account_id": "123456789012",
-      "version": "2012-10-17"
     }
   },
   {
@@ -766,9 +1183,9 @@
     "T.v_out": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "eu-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-2"
+      "name": "ap-east-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/ap-east-1"
     }
   },
   {
@@ -785,35 +1202,6 @@
     }
   },
   {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "me-south-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/me-south-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "statement",
-      "account_id": "123456789012",
-      "effect": "Allow",
-      "action": "sts:AssumeRole"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -824,55 +1212,6 @@
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "principal",
-      "account_id": "123456789012",
-      "service": "lambda.amazonaws.com"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "ec2:flow-log",
-      "flow_log_status": "ACTIVE",
-      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
-      "account_id": "123456789012",
-      "log_destination": "arn:aws:s3:::test_bucket",
-      "traffic_type": "ALL",
-      "deliver_logs_status": "SUCCESS",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
-      "log_destination_type": "s3"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
     }
   },
   {
@@ -902,57 +1241,6 @@
     }
   },
   {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "ec2:volume",
-      "availability_zone": "us-east-1a",
-      "account_id": "123456789012",
-      "volume_type": "gp2",
-      "size": 128,
-      "encrypted": false,
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "ec2:volume",
-      "availability_zone": "us-east-1a",
-      "account_id": "123456789012",
-      "volume_type": "gp2",
-      "size": 128,
-      "encrypted": false,
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
-    }
-  },
-  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -975,24 +1263,9 @@
     "T.v_out": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "eu-south-1",
+      "name": "ca-central-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-south-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
+      "arn": "arn:aws:::123456789012:region/ca-central-1"
     }
   },
   {
@@ -1011,31 +1284,16 @@
   {
     "T.label": "identified_resource",
     "T.v_in": {
-      "T.label": "region",
+      "T.label": "lambda:function",
       "account_id": "123456789012",
-      "name": "ap-east-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/ap-east-1"
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
     },
     "T.v_out": {
       "T.label": "metadata",
       "name": "alti",
       "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
     }
   },
   {
@@ -1054,231 +1312,6 @@
   {
     "T.label": "resource_link",
     "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-east-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/ap-east-1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ca-central-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ca-central-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-north-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-south-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-1"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-1"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-2"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-southeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "transient_resource_link",
-    "T.v_in": {
-      "T.label": "ec2:vpc",
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/16",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
-      "is_default": true
-    },
-    "T.v_out": {
-      "T.label": "ec2:flow-log",
-      "flow_log_status": "ACTIVE",
-      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
-      "account_id": "123456789012",
-      "log_destination": "arn:aws:s3:::test_bucket",
-      "traffic_type": "ALL",
-      "deliver_logs_status": "SUCCESS",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
-      "log_destination_type": "s3"
-    }
-  },
-  {
-    "T.label": "includes",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-3"
-    },
-    "T.v_out": {
-      "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
       "T.label": "region",
       "account_id": "123456789012",
       "name": "us-east-1",
@@ -1297,6 +1330,86 @@
     }
   },
   {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "ap-southeast-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/ap-southeast-2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-north-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-north-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-south-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-south-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-2"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "eu-west-3",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/eu-west-3"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -1307,21 +1420,6 @@
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
     }
   },
   {
@@ -1338,40 +1436,6 @@
     }
   },
   {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "ec2:subnet",
-      "last_ip": 167772415,
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/24",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
-      "first_ip": 167772160
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-west-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-west-2"
-    }
-  },
-  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -1382,68 +1446,6 @@
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-3"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "me-south-1",
-      "opt_in_status": "not-opted-in",
-      "arn": "arn:aws:::123456789012:region/me-south-1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
-    },
-    "T.v_out": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
     }
   },
   {
@@ -1457,36 +1459,6 @@
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "sa-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/sa-east-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-1"
     }
   },
   {
@@ -1503,55 +1475,6 @@
     }
   },
   {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-east-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-east-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "ec2:flow-log",
-      "flow_log_status": "ACTIVE",
-      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
-      "account_id": "123456789012",
-      "log_destination": "arn:aws:s3:::test_bucket",
-      "traffic_type": "ALL",
-      "deliver_logs_status": "SUCCESS",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
-      "log_destination_type": "s3"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-west-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-west-1"
-    }
-  },
-  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -1565,25 +1488,6 @@
     }
   },
   {
-    "T.label": "transient_resource_link",
-    "T.v_in": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    },
-    "T.v_out": {
-      "T.label": "lambda:function",
-      "account_id": "123456789012",
-      "function_name": "test_lambda_function_1",
-      "runtime": "python3.7",
-      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
-    }
-  },
-  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -1594,57 +1498,6 @@
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "cn-north-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/cn-north-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "assume_role_policy_document",
-    "T.v_in": {
-      "T.label": "assume_role_policy_document",
-      "account_id": "123456789012",
-      "version": "2012-10-17"
-    },
-    "T.v_out": {
-      "T.label": "iam:role",
-      "account_id": "123456789012",
-      "name": "test_role_1",
-      "description": "Test Role 1",
-      "arn": "arn:aws:iam::123456789012:role/test_role_1",
-      "max_session_duration": 3600,
-      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "ec2:flow-log",
-      "flow_log_status": "ACTIVE",
-      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
-      "account_id": "123456789012",
-      "log_destination": "arn:aws:s3:::test_bucket",
-      "traffic_type": "ALL",
-      "deliver_logs_status": "SUCCESS",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
-      "log_destination_type": "s3"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
     }
   },
   {
@@ -1661,98 +1514,6 @@
     }
   },
   {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "ap-northeast-2",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-northeast-2"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "eu-west-3",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/eu-west-3"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "ec2:subnet",
-      "last_ip": 167772415,
-      "account_id": "123456789012",
-      "cidr_block": "10.0.0.0/24",
-      "state": "available",
-      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
-      "first_ip": 167772160
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "iam:policy",
-      "account_id": "123456789012",
-      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
-      "name": "test_policy_1",
-      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}, {\"Action\": \"s3:GetObject\", \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::test_bucket\"}], \"Version\": \"2012-10-17\"}",
-      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
-      "default_version_id": "v1"
-    }
-  },
-  {
-    "T.label": "identified_resource",
-    "T.v_in": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "af-south-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/af-south-1"
-    },
-    "T.v_out": {
-      "T.label": "metadata",
-      "name": "alti",
-      "version": "2"
-    }
-  },
-  {
     "T.label": "includes",
     "T.v_in": {
       "T.label": "region",
@@ -1775,24 +1536,9 @@
     "T.v_out": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "ap-south-1",
+      "name": "eu-south-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-south-1"
-    }
-  },
-  {
-    "T.label": "resource_link",
-    "T.v_in": {
-      "T.label": "account",
-      "account_id": "123456789012",
-      "arn": "arn:aws::::account/123456789012"
-    },
-    "T.v_out": {
-      "T.label": "region",
-      "account_id": "123456789012",
-      "name": "us-gov-east-1",
-      "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-gov-east-1"
+      "arn": "arn:aws:::123456789012:region/eu-south-1"
     }
   },
   {
@@ -1811,13 +1557,96 @@
   {
     "T.label": "includes",
     "T.v_in": {
-      "T.label": "iam:policy",
+      "T.label": "account",
       "account_id": "123456789012",
-      "policy_id": "AWCHQMVWQZCZDLB1XJO5P",
-      "name": "test_policy_1",
-      "default_version_policy_document_text": "{\"Statement\": [{\"Action\": \"logs:CreateLogGroup\", \"Effect\": \"Allow\", \"Resource\": \"*\"}, {\"Action\": \"s3:GetObject\", \"Effect\": \"Allow\", \"Resource\": \"arn:aws:s3:::test_bucket\"}], \"Version\": \"2012-10-17\"}",
-      "arn": "arn:aws:iam::123456789012:policy/test_policy_1",
-      "default_version_id": "v1"
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "lambda:function",
+      "account_id": "123456789012",
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "assume_role_policy_document",
+      "account_id": "123456789012",
+      "version": "2012-10-17"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "assume_role_policy_document",
+      "account_id": "123456789012",
+      "version": "2012-10-17"
+    },
+    "T.v_out": {
+      "T.label": "metadata",
+      "name": "alti",
+      "version": "2"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "statement",
+      "account_id": "123456789012",
+      "effect": "Allow",
+      "action": "sts:AssumeRole"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "principal",
+      "account_id": "123456789012",
+      "service": "lambda.amazonaws.com"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "iam:role",
+      "account_id": "123456789012",
+      "name": "test_role_1",
+      "description": "Test Role 1",
+      "arn": "arn:aws:iam::123456789012:role/test_role_1",
+      "max_session_duration": 3600,
+      "assume_role_policy_document_text": "{\"Statement\": [{\"Action\": \"sts:AssumeRole\", \"Effect\": \"Allow\", \"Principal\": {\"Service\": \"lambda.amazonaws.com\"}, \"Sid\": \"\"}], \"Version\": \"2012-10-17\"}"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "s3:bucket",
+      "account_id": "123456789012",
+      "name": "test_bucket",
+      "arn": "arn:aws:s3:us-east-1:123456789012:bucket/test_bucket"
     },
     "T.v_out": {
       "T.label": "altimeter_snapshot"
@@ -1839,13 +1668,121 @@
     }
   },
   {
-    "T.label": "identified_resource",
+    "T.label": "includes",
     "T.v_in": {
+      "T.label": "ec2:volume",
+      "availability_zone": "us-east-1a",
+      "account_id": "123456789012",
+      "volume_type": "gp2",
+      "size": 128,
+      "encrypted": false,
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-ee1444e3"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "ec2:flow-log",
+      "flow_log_status": "ACTIVE",
+      "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "account_id": "123456789012",
+      "log_destination": "arn:aws:s3:::test_bucket",
+      "traffic_type": "ALL",
+      "deliver_logs_status": "SUCCESS",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:flow-log/fl-290d1baa",
+      "log_destination_type": "s3"
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "us-west-1",
+      "name": "me-south-1",
+      "opt_in_status": "not-opted-in",
+      "arn": "arn:aws:::123456789012:region/me-south-1"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "ec2:subnet",
+      "last_ip": 167772415,
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/24",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
+      "first_ip": 167772160
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "principal",
+    "T.v_in": {
+      "T.label": "principal",
+      "account_id": "123456789012",
+      "service": "lambda.amazonaws.com"
+    },
+    "T.v_out": {
+      "T.label": "statement",
+      "account_id": "123456789012",
+      "effect": "Allow",
+      "action": "sts:AssumeRole"
+    }
+  },
+  {
+    "T.label": "includes",
+    "T.v_in": {
+      "T.label": "ec2:vpc",
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/16",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-b4679527",
+      "is_default": true
+    },
+    "T.v_out": {
+      "T.label": "altimeter_snapshot"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "cn-northwest-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/us-west-1"
+      "arn": "arn:aws:::123456789012:region/cn-northwest-1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "ec2:subnet",
+      "last_ip": 167772415,
+      "account_id": "123456789012",
+      "cidr_block": "10.0.0.0/24",
+      "state": "available",
+      "arn": "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-20d4e2fd",
+      "first_ip": 167772160
     },
     "T.v_out": {
       "T.label": "metadata",
@@ -1854,18 +1791,63 @@
     }
   },
   {
-    "T.label": "identified_resource",
+    "T.label": "resource_link",
     "T.v_in": {
       "T.label": "region",
       "account_id": "123456789012",
-      "name": "ap-southeast-3",
+      "name": "us-east-1",
       "opt_in_status": "opt-in-not-required",
-      "arn": "arn:aws:::123456789012:region/ap-southeast-3"
+      "arn": "arn:aws:::123456789012:region/us-east-1"
+    },
+    "T.v_out": {
+      "T.label": "lambda:function",
+      "account_id": "123456789012",
+      "function_name": "test_lambda_function_1",
+      "runtime": "python3.7",
+      "arn": "arn:aws:lambda:us-east-1:123456789012:function:test_lambda_function_1"
+    }
+  },
+  {
+    "T.label": "identified_resource",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
     },
     "T.v_out": {
       "T.label": "metadata",
       "name": "alti",
       "version": "2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-west-2",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-west-2"
+    }
+  },
+  {
+    "T.label": "resource_link",
+    "T.v_in": {
+      "T.label": "account",
+      "account_id": "123456789012",
+      "arn": "arn:aws::::account/123456789012"
+    },
+    "T.v_out": {
+      "T.label": "region",
+      "account_id": "123456789012",
+      "name": "us-east-1",
+      "opt_in_status": "opt-in-not-required",
+      "arn": "arn:aws:::123456789012:region/us-east-1"
     }
   }
 ]


### PR DESCRIPTION
This PR ensures all the vertices added by the graph-altimeter scan have the `account_id` property set to the proper
value.
It also fixes the dependency `Markupsafe` that was causing the builds to fail.

Notice that for this PR to work the graph_altimeter version used must include this [commit](https://github.com/manelmontilla/altimeter/pull/9/commits/04e2f70f1e7492e28c71205782bf410ca43e5ac9). That's the case now, as is included in the `dev` branch of the fork that we are using; notice the dependency: `git+https://github.com/manelmontilla/altimeter.git@dev` in de requirements/requirements.txt file.