### PR TITLE
bin/graph_altimeter_batch.py: change default logging level to WARNING

### DIFF
--- a/bin/graph_altimeter_batch.py
+++ b/bin/graph_altimeter_batch.py
@@ -79,9 +79,9 @@ def run_scan():
 def config_root_logger(debug):
     """Configures the root logger. It sets the logging level to ``DEBUG`` if
     the param ``debug`` is true. Otherwise, the logging level is set to
-    ``INFO``."""
+    ``WARNING``."""
     root_logger = logging.getLogger()
-    log_level = logging.DEBUG if debug else logging.INFO
+    log_level = logging.DEBUG if debug else logging.WARNING
     root_logger.setLevel(log_level)
 
     logging_handler = logging.StreamHandler(stream=sys.stderr)


### PR DESCRIPTION
This PR changes the default logging level to WARNING because Altimeter's INFO
level is too verbose.