### PR TITLE
graph_altimeter/scan: add account_id to vertices before expanding IAM policies

### DIFF
--- a/graph_altimeter/scan/config.py
+++ b/graph_altimeter/scan/config.py
@@ -133,7 +133,7 @@ def account_accessor_dict(target_account_role, trampoline_account_role_arn):
         'cache_creds': True,
         'multi_hop_accessors': [
             {
-                'role_session_name': "audit_session",
+                'role_session_name': "graph-altimeter",
                 'access_steps': access_steps,
             }
         ]

--- a/requirements/requirements-altimeter.in
+++ b/requirements/requirements-altimeter.in
@@ -3,7 +3,7 @@ gremlinpython==3.4.12
 policyuniverse==1.4.0.20220110
 
 # neptune_python_utils dependencies.
-boto3==1.20.44
+boto3==1.21.20
 backoff==1.11.1
 aiohttp==3.8.0
 

--- a/requirements/requirements-altimeter.txt
+++ b/requirements/requirements-altimeter.txt
@@ -27,12 +27,12 @@ aws-xray-sdk==2.9.0
     # via moto
 backoff==1.11.1
     # via -r /work/requirements-altimeter.in
-boto3==1.20.44
+boto3==1.21.20
     # via
     #   -r /work/requirements-altimeter.in
     #   aws-sam-translator
     #   moto
-botocore==1.23.54
+botocore==1.24.46
     # via
     #   aws-xray-sdk
     #   boto3

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -6,7 +6,7 @@ policyuniverse==1.4.0.20220110
 git+https://github.com/manelmontilla/altimeter.git@dev
 
 # neptune_python_utils dependencies.
-boto3==1.20.44
+boto3==1.21.20
 backoff==1.11.1
 aiohttp==3.8.0
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -31,13 +31,13 @@ aws-xray-sdk==2.9.0
     # via moto
 backoff==1.11.1
     # via -r /work/requirements-dev.in
-boto3==1.20.44
+boto3==1.21.20
     # via
     #   -r /work/requirements-dev.in
     #   altimeter
     #   aws-sam-translator
     #   moto
-botocore==1.23.54
+botocore==1.24.46
     # via
     #   aws-xray-sdk
     #   boto3
@@ -157,7 +157,7 @@ pycodestyle==2.7.0
     # via flake8
 pycparser==2.21
     # via cffi
-pydantic==1.9.0
+pydantic==1.8.2
     # via altimeter
 pyflakes==2.3.1
     # via flake8

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -6,6 +6,6 @@ policyuniverse==1.4.0.20220110
 git+https://github.com/manelmontilla/altimeter.git@dev
 
 # neptune_python_utils dependencies.
-boto3==1.20.44
+boto3==1.21.20
 backoff==1.11.1
 aiohttp==3.8.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,11 +20,11 @@ aws-requests-auth==0.4.3
     # via altimeter
 backoff==1.11.1
     # via -r /work/requirements.in
-boto3==1.20.44
+boto3==1.21.20
     # via
     #   -r /work/requirements.in
     #   altimeter
-botocore==1.23.54
+botocore==1.24.46
     # via
     #   boto3
     #   s3transfer
@@ -66,7 +66,7 @@ multidict==6.0.2
     #   yarl
 policyuniverse==1.4.0.20220110
     # via -r /work/requirements.in
-pydantic==1.9.0
+pydantic==1.8.2
     # via altimeter
 pyparsing==3.0.8
     # via rdflib


### PR DESCRIPTION
This PR adds the `account_id` property to vertices before expanding the IAM
policies. Otherwise, the expansion is not possible because this information is
needed.

It also changes the name of the assume-role session to `graph-altimeter` which
can be easily identified in logs.