### PR TITLE
all: improve logging in INFO mode

### DIFF
--- a/bin/graph_altimeter_batch.py
+++ b/bin/graph_altimeter_batch.py
@@ -53,7 +53,7 @@ def run_scan():
 
     for i, account_id in enumerate(accounts):
         logger.info(
-            "scanning account %s (%s/%s)",
+            "scanning account %s (%d/%d)",
             account_id,
             i + 1,
             len(accounts)

--- a/bin/graph_altimeter_batch.py
+++ b/bin/graph_altimeter_batch.py
@@ -51,8 +51,13 @@ def run_scan():
     else:
         accounts = get_aws_accounts(asset_inventory_api_url)
 
-    for account_id in accounts:
-        logger.info("scanning account %s", account_id)
+    for i, account_id in enumerate(accounts):
+        logger.info(
+            "scanning account %s (%s/%s)",
+            account_id,
+            i + 1,
+            len(accounts)
+        )
         config = AltimeterConfig.from_env()
         scan_config = config.config_dict(
             account_id,
@@ -80,9 +85,9 @@ def config_root_logger(debug):
         root_logger.setLevel(logging.DEBUG)
     else:
         root_logger.setLevel(logging.INFO)
-        # Altimeter's INFO level is too verbose. So we set it to WARNING on
+        # Altimeter's INFO level is too verbose. So we set it to ERROR on
         # non-debug mode.
-        logging.getLogger('altimeter').setLevel(logging.WARNING)
+        logging.getLogger('altimeter').setLevel(logging.ERROR)
 
     logging_handler = logging.StreamHandler(stream=sys.stderr)
     formatter = logging.Formatter(

--- a/graph_altimeter/scan/iam/__init__.py
+++ b/graph_altimeter/scan/iam/__init__.py
@@ -172,11 +172,11 @@ def _aws_arn_rules(document, account_id):
             except InvalidArnPatternError as e:
                 # There could be policy documents that contain invalid
                 # policies.
-                logger.warning(e)
+                logger.debug(e)
             except EmptyActionsError:
                 # The statement does not contain any action.
                 # TODO: take into account the "NotAction" field.
-                logger.warning('statement with no actions')
+                logger.debug('statement with no actions')
     return rules
 
 

--- a/graph_altimeter/scan/neptune_client.py
+++ b/graph_altimeter/scan/neptune_client.py
@@ -54,6 +54,7 @@ class GraphAltimeterNeptuneClient(AltimeterNeptuneClient):
         link_from_id param."""
         cnt = 0
         t = g
+        logger.info('Writing %s vertices', len(vertices))
         for r in vertices:
             vertex_id = f'{r["~id"]}_{scan_id}'
             t = (
@@ -82,7 +83,7 @@ class GraphAltimeterNeptuneClient(AltimeterNeptuneClient):
             cnt += 1
             if cnt % 100 == 0 or cnt == len(vertices):
                 try:
-                    self.logger.info(
+                    self.logger.debug(
                         "Writing vertices %i of %i",
                         cnt,
                         len(vertices)
@@ -104,6 +105,7 @@ class GraphAltimeterNeptuneClient(AltimeterNeptuneClient):
         """
         cnt = 0
         t = g
+        logger.info('Writing %s edges', len(edges))
         for r in edges:
             to_id = f'{r["~to"]}_{scan_id}'
             from_id = f'{r["~from"]}_{scan_id}'
@@ -136,7 +138,7 @@ class GraphAltimeterNeptuneClient(AltimeterNeptuneClient):
             cnt += 1
             if cnt % 100 == 0 or cnt == len(edges):
                 try:
-                    self.logger.info(
+                    self.logger.debug(
                         "Writing edges %i of %i",
                         cnt,
                         len(edges)

--- a/graph_altimeter/scan/neptune_client.py
+++ b/graph_altimeter/scan/neptune_client.py
@@ -54,7 +54,7 @@ class GraphAltimeterNeptuneClient(AltimeterNeptuneClient):
         link_from_id param."""
         cnt = 0
         t = g
-        logger.info('Writing %s vertices', len(vertices))
+        logger.info('Writing %d vertices', len(vertices))
         for r in vertices:
             vertex_id = f'{r["~id"]}_{scan_id}'
             t = (
@@ -105,7 +105,7 @@ class GraphAltimeterNeptuneClient(AltimeterNeptuneClient):
         """
         cnt = 0
         t = g
-        logger.info('Writing %s edges', len(edges))
+        logger.info('Writing %d edges', len(edges))
         for r in edges:
             to_id = f'{r["~to"]}_{scan_id}'
             from_id = f'{r["~from"]}_{scan_id}'


### PR DESCRIPTION
This PR introduces the following modifications regarding logging:

- When in `INFO` mode it does not write the log lines informing the batch of 
vertices and edges that it writes, like for instance: 
```
INFO - Writing edges 3000 of 5008
```
Instead, it writes one line when writing the Vertices and another line when writing the Edges.

- it includes the account ordinal and the number of the accounts to scan in the line informing about the account to be written, for instance:
```
INFO - Scanning account 123123 (10/300)
``` 
 - It lowers the level of logging of Altimeter from `WARNING` to `ERROR`.