### PR TITLE
all: normalize the aws account identifiers

### DIFF
--- a/bin/graph_altimeter_batch.py
+++ b/bin/graph_altimeter_batch.py
@@ -8,7 +8,7 @@ import logging
 from altimeter.core.config import AWSConfig
 
 from graph_altimeter import EnvVarNotSetError
-from graph_altimeter.scan import run, normalize_account_id
+from graph_altimeter.scan import run, normalize_aws_account
 from graph_altimeter.scan.config import AltimeterConfig
 from graph_altimeter.asset_inventory import get_aws_accounts
 
@@ -53,7 +53,7 @@ def run_scan():
                 i + 1,
                 len(accounts)
             )
-            account_id = normalize_account_id(account_id)
+            account_id = normalize_aws_account(account_id)
             config = AltimeterConfig.from_env()
             scan_config = config.config_dict(
                 account_id,

--- a/graph_altimeter/scan/__init__.py
+++ b/graph_altimeter/scan/__init__.py
@@ -164,19 +164,18 @@ def remove_scan_files(temp_dir, scan_id):
 
 
 class InvalidAWSAccount(Exception):
-    """Returned when normalized an AWS account identifier if the format is not
-    recognized."""
+    """Returned when trying to normalize a malformed AWS account identifier."""
 
-    def __init__(self, AWS_account):
+    def __init__(self, aws_account):
         super().__init__(
-            f'the format of the AWS_account: {AWS_account} is invalid'
+            f'the format of the AWS_account: {aws_account} is invalid'
         )
 
 
-def normalize_account_id(aws_account):
-    """if the input is an AWS account arn, it returns the correspondent
+def normalize_aws_account(aws_account):
+    """if the input is an AWS account arn, it returns the corresponding
     account id. If the input is already an account id it just returns it.
-    Otherwise it raises a InvalidAWSAccount identifier exception.
+    Otherwise it raises an InvalidAWSAccount exception.
     """
     match = arn_aws_account_re.match(aws_account)
     if match:

--- a/graph_altimeter/scan/__init__.py
+++ b/graph_altimeter/scan/__init__.py
@@ -35,7 +35,7 @@ from graph_altimeter.scan.postprocess import postprocess
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-arn_aws_account_re = re.compile('^arn:aws:iam::([0-9]{12}):root$')
+aws_account_arn_re = re.compile('^arn:aws:iam::([0-9]{12}):root$')
 
 aws_account_id_re = re.compile('^[0-9]{12}$')
 
@@ -177,7 +177,7 @@ def normalize_aws_account(aws_account):
     account id. If the input is already an account id it just returns it.
     Otherwise it raises an InvalidAWSAccount exception.
     """
-    match = arn_aws_account_re.match(aws_account)
+    match = aws_account_arn_re.match(aws_account)
     if match:
         return match.group(1)
     if aws_account_id_re.match(aws_account):

--- a/tests/test_normalize_account_id.py
+++ b/tests/test_normalize_account_id.py
@@ -1,0 +1,38 @@
+"""Tests for normalizing AWS accounts."""
+import pytest
+from graph_altimeter.scan import normalize_account_id, InvalidAWSAccount
+
+
+def test_normalize_account_id_from_valid_arn():
+    """Tests that the normalize_account_id function properly extracts the
+    account id from an arn."""
+    account_id = "123456789111"
+    account_arn = f'arn:aws:iam::{account_id}:root'
+    # Test it extracts
+    got_account_id = normalize_account_id(account_arn)
+    assert got_account_id == account_id
+
+
+def test_normalize_account_id_from_already_account_id():
+    """Tests that the normalize_account_id function returns the account_id
+    passed in."""
+    account_id = "123456789111"
+    # Test it extracts
+    got_account_id = normalize_account_id(account_id)
+    assert got_account_id == account_id
+
+
+def test_normalize_account_id_from_invalid_arn():
+    """Tests that the normalize_account_id function returns an exception
+    for an invalid account arn."""
+    account_arn = "arn:aws:iam::111:root"
+    with pytest.raises(InvalidAWSAccount):
+        normalize_account_id(account_arn)
+
+
+def test_normalize_account_id_from_invalid_account_id():
+    """Tests that the normalize_account_id function returns an exception
+    for an invalid account id."""
+    account_id = "111"
+    with pytest.raises(InvalidAWSAccount):
+        normalize_account_id(account_id)

--- a/tests/test_normalize_account_id.py
+++ b/tests/test_normalize_account_id.py
@@ -1,4 +1,4 @@
-"""Tests for normalizing AWS accounts."""
+"""Tests for AWS account ID normalization."""
 import pytest
 from graph_altimeter.scan import normalize_account_id, InvalidAWSAccount
 

--- a/tests/test_normalize_account_id.py
+++ b/tests/test_normalize_account_id.py
@@ -1,38 +1,38 @@
 """Tests for AWS account ID normalization."""
 import pytest
-from graph_altimeter.scan import normalize_account_id, InvalidAWSAccount
+from graph_altimeter.scan import normalize_aws_account, InvalidAWSAccount
 
 
-def test_normalize_account_id_from_valid_arn():
-    """Tests that the normalize_account_id function properly extracts the
+def test_normalize_aws_account_from_valid_arn():
+    """Tests that the normalize_aws_account function properly extracts the
     account id from an arn."""
     account_id = "123456789111"
     account_arn = f'arn:aws:iam::{account_id}:root'
     # Test it extracts
-    got_account_id = normalize_account_id(account_arn)
+    got_account_id = normalize_aws_account(account_arn)
     assert got_account_id == account_id
 
 
-def test_normalize_account_id_from_already_account_id():
-    """Tests that the normalize_account_id function returns the account_id
+def test_normalize_aws_account_from_already_account_id():
+    """Tests that the normalize_aws_account function returns the account_id
     passed in."""
     account_id = "123456789111"
     # Test it extracts
-    got_account_id = normalize_account_id(account_id)
+    got_account_id = normalize_aws_account(account_id)
     assert got_account_id == account_id
 
 
-def test_normalize_account_id_from_invalid_arn():
-    """Tests that the normalize_account_id function returns an exception
+def test_normalize_aws_account_from_invalid_arn():
+    """Tests that the normalize_aws_account function returns an exception
     for an invalid account arn."""
     account_arn = "arn:aws:iam::111:root"
     with pytest.raises(InvalidAWSAccount):
-        normalize_account_id(account_arn)
+        normalize_aws_account(account_arn)
 
 
-def test_normalize_account_id_from_invalid_account_id():
-    """Tests that the normalize_account_id function returns an exception
+def test_normalize_aws_account_from_invalid_account_id():
+    """Tests that the normalize_aws_account function returns an exception
     for an invalid account id."""
     account_id = "111"
     with pytest.raises(InvalidAWSAccount):
-        normalize_account_id(account_id)
+        normalize_aws_account(account_id)


### PR DESCRIPTION
This PR normalizes the AWS account identifiers to the short form, e.g.: 123456789111, that it gets from the asset inventory before scanning. 